### PR TITLE
[Feat]#54-그룹 페이지 셀의 하단과 상단 크기값을 정적으로 지정

### DIFF
--- a/ToDwoong/ToDwoong/Presentation/GroupList/View/GroupListView.swift
+++ b/ToDwoong/ToDwoong/Presentation/GroupList/View/GroupListView.swift
@@ -91,9 +91,10 @@ extension GroupListView {
     
         
         tableView.snp.makeConstraints { make in
-            make.top.equalTo(addButton.snp.bottom).offset(-16)
+            make.top.equalTo(addButton.snp.bottom).offset(5)
             make.leading.equalToSuperview().offset(0)
             make.trailing.equalToSuperview().offset(0)
+            make.bottom.equalToSuperview().offset(-20)
         }
     }
     


### PR DESCRIPTION
<!-- 
<제목 양식>

[기능 라벨] #이슈번호 - 기능 1줄 요약
ex) [Feat] #1 - 프로젝트 세팅
ex) [Docs] #2 - Readme 파일 수정
-->


## 연관된 이슈
<!-- ex) #이슈번호 -->

> #54 

## 작업 내용
<!--
이번 PR에서 작업한 내용을 간략히 설명해주세요
메서드의 경우 사용 예시를 적어주세요
-->

>그룹 페이지 셀의 하단과 상단 크기값을 정적으로 지정해서 좀 더 자연스럽게 보이게끔 수정했습니다.

## 리뷰 요구사항 (선택)
<!--
리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
-->

> 수정할부분이 있다면 말씀해주세요.


## 스크린샷 (선택)

<!--  양식
(옆으로 쭉쭉 늘리거나 아래로 추가해서 사용하시면 됩니다)

|제목|제목|
|---|---|
|<img src="이미지 링크" width="300"/>|<img src="이미지 링크" width="300"/>|

-->
![Mar-06-2024 11-07-10](https://github.com/NBCAMP-ToDwoong/todwoong/assets/123481645/a52eb971-e562-4f78-8450-3058043b7644)
