### PR TITLE
[Chore] #103 - 그룹 추가 페이지 UI 변경 및 뒤로가기 기능 구현

### DIFF
--- a/ToDwoong/ToDwoong/Presentation/AddGroup/View/AddGroupView.swift
+++ b/ToDwoong/ToDwoong/Presentation/AddGroup/View/AddGroupView.swift
@@ -15,12 +15,23 @@ final class AddGroupView: UIView {
     
     var palleteButtonTapped: ((UIButton) -> Void)?
     var addButtonTapped: (() -> Void)?
+    var cancelButtonTapped: (() -> Void)?
     
     // MARK: - UI Properties
+    
+    lazy var cancelButton: UIButton = {
+        let button = UIButton()
+        button.setImage(UIImage(systemName: "xmark"), for: .normal)
+        button.tintColor = TDStyle.color.mainTheme
+        button.addTarget(self, action: #selector(cancelButtonAction), for: .touchUpInside)
+        
+        return button
+    }()
     
     private var titleLabel: UILabel = {
         let label = UILabel()
         label.text = "그룹"
+        label.font = TDStyle.font.body(style: .bold)
         
         return label
     }()
@@ -28,7 +39,7 @@ final class AddGroupView: UIView {
     lazy var addButton: UIButton = {
         let button = UIButton()
         button.setTitle("저장", for: .normal)
-        button.setTitleColor(.systemBlue, for: .normal)
+        button.setTitleColor(TDStyle.color.mainTheme, for: .normal)
         button.addTarget(self, action: #selector(addButtonAction), for: .touchUpInside)
         button.isEnabled = false
         button.setTitleColor(.systemGray3, for: .disabled)
@@ -155,12 +166,16 @@ extension AddGroupView {
             buttonTapped(sender)
         }
     }
-    @objc func addButtonAction(sender: UIButton) {
+    @objc func addButtonAction() {
         if let buttonTapped = addButtonTapped {
             buttonTapped()
         }
-        
         NotificationCenter.default.post(name: .GroupDataUpdatedNotification, object: nil)
+    }
+    @objc func cancelButtonAction() {
+        if let buttonTapped = cancelButtonTapped {
+            buttonTapped()
+        }
     }
 }
 
@@ -171,6 +186,7 @@ extension AddGroupView {
         self.backgroundColor = .white
         
         [
+            cancelButton,
             titleLabel,
             addButton,
             seperateLine,
@@ -199,13 +215,17 @@ extension AddGroupView {
         ].forEach { palleteStackView2.addArrangedSubview($0) }
         
         titleLabel.snp.makeConstraints { make in
-            make.top.equalTo(safeAreaLayoutGuide).offset(40)
+            make.top.equalTo(safeAreaLayoutGuide).offset(16)
+            make.centerX.equalToSuperview()
+        }
+        
+        cancelButton.snp.makeConstraints { make in
+            make.centerY.equalTo(titleLabel)
             make.leading.equalToSuperview().offset(16)
         }
         
         addButton.snp.makeConstraints { make in
-            make.top.equalTo(safeAreaLayoutGuide).offset(40)
-            make.height.equalTo(titleLabel.snp.height)
+            make.centerY.equalTo(titleLabel)
             make.trailing.equalToSuperview().offset(-16)
         }
         

--- a/ToDwoong/ToDwoong/Presentation/AddGroup/ViewController/AddGroupViewController.swift
+++ b/ToDwoong/ToDwoong/Presentation/AddGroup/ViewController/AddGroupViewController.swift
@@ -134,6 +134,10 @@ extension AddGroupViewController {
                 self.dismiss(animated: true)
             }
         }
+        
+        addGroupView.cancelButtonTapped = {
+            self.dismiss(animated: true)
+        }
     }
 }
 


### PR DESCRIPTION
<!-- 
<제목 양식>

[기능 라벨] #이슈번호 - 기능 1줄 요약
ex) [Feat] #1 - 프로젝트 세팅
ex) [Docs] #2 - Readme 파일 수정
-->


## 연관된 이슈
<!-- ex) #이슈번호 -->

> #103

## 작업 내용
<!--
이번 PR에서 작업한 내용을 간략히 설명해주세요
메서드의 경우 사용 예시를 적어주세요
-->

> 
타이틀 위치 변경
뒤로가기 기능 구현
저장 버튼 색상 변경 (기존: systemBlue -> 변경: mainTheme)

## 리뷰 요구사항 (선택)
<!--
리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
-->

>


## 스크린샷 (선택)

<!--  양식
(옆으로 쭉쭉 늘리거나 아래로 추가해서 사용하시면 됩니다)

|제목|제목|
|---|---|
|<img src="이미지 링크" width="300"/>|<img src="이미지 링크" width="300"/>|

-->
|시연|
|---|
|<img src="https://github.com/NBCAMP-ToDwoong/todwoong/assets/151711359/2b46a4b1-9922-47f3-a305-a0a5947c4048" width="300"/>|