### PR TITLE
[Feat]#114-투두 추가 페이지 누락 기능 구현

### DIFF
--- a/ToDwoong/ToDwoong/Presentation/AddTodo/Cells/LocationTableViewCell.swift
+++ b/ToDwoong/ToDwoong/Presentation/AddTodo/Cells/LocationTableViewCell.swift
@@ -38,10 +38,11 @@ class LocationTableViewCell: UITableViewCell {
         contentView.addSubview(titleLabel)
         titleLabel.text = "위치"
         titleLabel.font = TDStyle.font.body(style: .regular)
+
         titleLabel.snp.makeConstraints { make in
             make.top.equalToSuperview().offset(10)
             make.leading.equalToSuperview().offset(30)
-            make.trailing.lessThanOrEqualToSuperview().offset(-16)
+            make.trailing.lessThanOrEqualToSuperview().offset(-30)
         }
     }
     
@@ -51,19 +52,37 @@ class LocationTableViewCell: UITableViewCell {
         hasLocationChip = false
 
         if let place = selectedPlace, !place.isEmpty {
-            let newChipView = InfoChipView(text: place, color: TDStyle.color.lightGray, showDeleteButton: true)
+            let maxCharacters = 18
+            let trimmedPlace: String
+            if place.count > maxCharacters {
+                let endIndex = place.index(place.startIndex, offsetBy: maxCharacters - 3)
+                trimmedPlace = place[..<endIndex] + "..."
+            } else {
+                trimmedPlace = place
+            }
+            
+            let newChipView = InfoChipView(text: trimmedPlace, color: TDStyle.color.lightGray, showDeleteButton: true)
             hasLocationChip = true
             newChipView.delegate = self
             contentView.addSubview(newChipView)
             chipView = newChipView
             chipView?.snp.makeConstraints { make in
-                make.top.equalTo(titleLabel.snp.bottom).offset(6)
+                make.centerY.equalTo(titleLabel.snp.centerY)
                 make.trailing.equalToSuperview().offset(-30)
                 make.height.equalTo(30)
             }
 
+            if let chipView = chipView {
+                titleLabel.snp.makeConstraints { make in
+                    make.trailing.lessThanOrEqualTo(chipView.snp.leading).offset(-10).priority(.high)
+                }
+            }
+
             accessoryType = .none
         } else {
+            titleLabel.snp.makeConstraints { make in
+                make.trailing.lessThanOrEqualToSuperview().offset(-30)
+            }
             accessoryType = .disclosureIndicator
         }
     }

--- a/ToDwoong/ToDwoong/Presentation/AddTodo/Cells/LocationTableViewCell.swift
+++ b/ToDwoong/ToDwoong/Presentation/AddTodo/Cells/LocationTableViewCell.swift
@@ -40,7 +40,7 @@ class LocationTableViewCell: UITableViewCell {
         titleLabel.font = TDStyle.font.body(style: .regular)
 
         titleLabel.snp.makeConstraints { make in
-            make.top.equalToSuperview().offset(10)
+            make.top.equalToSuperview().offset(12)
             make.leading.equalToSuperview().offset(30)
             make.trailing.lessThanOrEqualToSuperview().offset(-30)
         }
@@ -52,11 +52,11 @@ class LocationTableViewCell: UITableViewCell {
         hasLocationChip = false
 
         if let place = selectedPlace, !place.isEmpty {
-            let maxCharacters = 18
+            let maxCharacters = 15
             let trimmedPlace: String
             if place.count > maxCharacters {
-                let endIndex = place.index(place.startIndex, offsetBy: maxCharacters - 3)
-                trimmedPlace = place[..<endIndex] + "..."
+                let endIndex = place.index(place.startIndex, offsetBy: maxCharacters)
+                trimmedPlace = place[..<endIndex] + ".."
             } else {
                 trimmedPlace = place
             }

--- a/ToDwoong/ToDwoong/Presentation/AddTodo/Modals/GroupSelectModal.swift
+++ b/ToDwoong/ToDwoong/Presentation/AddTodo/Modals/GroupSelectModal.swift
@@ -158,7 +158,7 @@ extension GroupSelectModal {
         
         addGroupButton.snp.makeConstraints { make in
             make.top.equalTo(separatorLine.snp.bottom).offset(4)
-            make.left.left.equalToSuperview().inset(5)
+            make.left.right.equalToSuperview().inset(5)
             make.height.equalTo(36)
         }
         

--- a/ToDwoong/ToDwoong/Presentation/AddTodo/Modals/GroupSelectModal.swift
+++ b/ToDwoong/ToDwoong/Presentation/AddTodo/Modals/GroupSelectModal.swift
@@ -196,6 +196,7 @@ extension GroupSelectModal: UITableViewDataSource {
         let category = groupList[indexPath.row]
         let isSelected = category == selectedCategory
         cell.configure(with: category, isSelected: isSelected)
+        updateSaveButtonAction()
         
         return cell
     }

--- a/ToDwoong/ToDwoong/Presentation/AddTodo/Modals/GroupSelectModal.swift
+++ b/ToDwoong/ToDwoong/Presentation/AddTodo/Modals/GroupSelectModal.swift
@@ -88,6 +88,11 @@ final class GroupSelectModal: UIViewController {
         setTableView()
         setAddGroupButton()
         configureModalStyle()
+        setNotifications()
+    }
+    
+    deinit {
+        NotificationCenter.default.removeObserver(self)
     }
     
     private func configureModalStyle() {
@@ -128,6 +133,11 @@ extension GroupSelectModal {
     
     @objc func closeModal() {
         dismiss(animated: true, completion: nil)
+    }
+    
+    @objc func groupDataUpdated() {
+        groupList = CoreDataManager.shared.readCategories()
+        tableView.reloadData()
     }
 }
 
@@ -177,6 +187,14 @@ extension GroupSelectModal {
         tableView.dataSource = self
         tableView.delegate = self
         tableView.register(UITableViewCell.self, forCellReuseIdentifier: "groupTableViewCellIdentifier")
+    }
+    
+    private func setNotifications() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(groupDataUpdated),
+            name: .GroupDataUpdatedNotification,
+            object: nil)
     }
 }
 

--- a/ToDwoong/ToDwoong/Presentation/AddTodo/Modals/GroupSelectModal.swift~HEAD
+++ b/ToDwoong/ToDwoong/Presentation/AddTodo/Modals/GroupSelectModal.swift~HEAD
@@ -39,7 +39,7 @@ final class GroupSelectModal: UIViewController {
     }()
     
     private lazy var saveButton: UIButton = {
-        createNotificationButton(title: "닫기", method: #selector(closeModal), color: TDStyle.color.mainDarkTheme)
+        createNotificationButton(title: "저장", method: #selector(saveGroup), color: TDStyle.color.mainDarkTheme)
     }()
     
     private func createNotificationButton(title: String,
@@ -73,7 +73,7 @@ final class GroupSelectModal: UIViewController {
         let tableView = UITableView(frame: .zero, style: .grouped)
         tableView.backgroundColor = .white
         tableView.contentInset = UIEdgeInsets(top: -35, left: 0, bottom: 0, right: 0)
-        tableView.register(GroupSelectModalTableViewCell.self, forCellReuseIdentifier: "GroupSelectModalTableViewCell")
+        
         return tableView
     }()
     
@@ -96,18 +96,6 @@ final class GroupSelectModal: UIViewController {
             presentationController.prefersGrabberVisible = true
         }
     }
-    
-    private func updateSaveButtonAction() {
-        if selectedCategory != nil {
-            saveButton.setTitle("저장", for: .normal)
-            saveButton.removeTarget(nil, action: nil, for: .allEvents)
-            saveButton.addTarget(self, action: #selector(saveGroup), for: .touchUpInside)
-        } else {
-            saveButton.setTitle("닫기", for: .normal)
-            saveButton.removeTarget(nil, action: nil, for: .allEvents)
-            saveButton.addTarget(self, action: #selector(closeModal), for: .touchUpInside)
-        }
-    }
 }
 
 // MARK: - @objc Method
@@ -124,10 +112,6 @@ extension GroupSelectModal {
         let addGroupViewController = AddGroupViewController()
         addGroupViewController.modalPresentationStyle = .fullScreen
         self.present(addGroupViewController, animated: true, completion: nil)
-    }
-    
-    @objc func closeModal() {
-        dismiss(animated: true, completion: nil)
     }
 }
 
@@ -158,15 +142,14 @@ extension GroupSelectModal {
         
         addGroupButton.snp.makeConstraints { make in
             make.top.equalTo(separatorLine.snp.bottom).offset(4)
-            make.left.left.equalToSuperview().inset(5)
-            make.height.equalTo(36)
+            make.height.equalTo(44)
         }
         
         tableView.snp.remakeConstraints { make in
             make.top.equalTo(addGroupButton.snp.bottom).offset(4)
             make.leading.trailing.bottom.equalTo(view.safeAreaLayoutGuide)
         }
-        
+
     }
     
     private func setAddGroupButton() {
@@ -188,18 +171,18 @@ extension GroupSelectModal: UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: "GroupSelectModalTableViewCell",
-                                                       for: indexPath) as? GroupSelectModalTableViewCell else {
-            fatalError("Unable to dequeue a CategoryTableViewCell.")
-        }
+        let cell = tableView.dequeueReusableCell(withIdentifier: "groupTableViewCellIdentifier", for: indexPath)
+        let group = groupList[indexPath.row]
+        cell.textLabel?.text = group.title
         
-        let category = groupList[indexPath.row]
-        let isSelected = category == selectedCategory
-        cell.configure(with: category, isSelected: isSelected)
+        if let selectedCategory = selectedCategory, selectedCategory == group {
+            cell.accessoryType = .checkmark
+        } else {
+            cell.accessoryType = .none
+        }
         
         return cell
     }
-    
 }
 
 // MARK: - UITableViewDelegate
@@ -216,7 +199,6 @@ extension GroupSelectModal: UITableViewDelegate {
             cell.accessoryType = .checkmark
             cell.tintColor = TDStyle.color.mainDarkTheme
             selectedCategory = groupList[indexPath.row]
-            updateSaveButtonAction()
         }
         
         tableView.deselectRow(at: indexPath, animated: true)
@@ -225,61 +207,10 @@ extension GroupSelectModal: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didDeselectRowAt indexPath: IndexPath) {
         if let cell = tableView.cellForRow(at: indexPath) {
             cell.accessoryType = .none
-            updateSaveButtonAction()
         }
     }
     
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         return 44
-    }
-}
-
-class GroupSelectModalTableViewCell: UITableViewCell {
-    let iconImageView: UIImageView = {
-        let imageView = UIImageView()
-        imageView.contentMode = .scaleAspectFit
-        imageView.translatesAutoresizingMaskIntoConstraints = false
-        return imageView
-    }()
-    
-    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
-        super.init(style: style, reuseIdentifier: reuseIdentifier)
-        setupViews()
-    }
-    
-    required init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-    
-    private func setupViews() {
-        addSubview(iconImageView)
-        iconImageView.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 15).isActive = true
-        iconImageView.centerYAnchor.constraint(equalTo: self.centerYAnchor).isActive = true
-        iconImageView.widthAnchor.constraint(equalToConstant: 30).isActive = true
-        iconImageView.heightAnchor.constraint(equalToConstant: 30).isActive = true
-        
-        textLabel?.translatesAutoresizingMaskIntoConstraints = false
-        textLabel?.leadingAnchor.constraint(equalTo: iconImageView.trailingAnchor, constant: 15).isActive = true
-        textLabel?.centerYAnchor.constraint(equalTo: self.centerYAnchor).isActive = true
-    }
-    
-    func configure(with category: Category, isSelected: Bool) {
-        textLabel?.text = category.title
-        if let colorString = category.color {
-            let color = UIColor(hex: colorString)
-            let imageSize = CGSize(width: 30, height: 30)
-            let roundedImage = UIImage.roundedImage(color: color, size: imageSize)
-            iconImageView.image = roundedImage
-        }
-        accessoryType = isSelected ? .checkmark : .none
-    }
-    
-    private func createCircularImage(with color: UIColor, size: CGSize) -> UIImage {
-        let renderer = UIGraphicsImageRenderer(size: size)
-        return renderer.image { context in
-            context.cgContext.setFillColor(color.cgColor)
-            context.cgContext.addEllipse(in: CGRect(origin: .zero, size: size))
-            context.cgContext.drawPath(using: .fill)
-        }
     }
 }

--- a/ToDwoong/ToDwoong/Presentation/AddTodo/Modals/GroupSelectModal.swift~HEAD_0
+++ b/ToDwoong/ToDwoong/Presentation/AddTodo/Modals/GroupSelectModal.swift~HEAD_0
@@ -39,7 +39,7 @@ final class GroupSelectModal: UIViewController {
     }()
     
     private lazy var saveButton: UIButton = {
-        createNotificationButton(title: "닫기", method: #selector(closeModal), color: TDStyle.color.mainDarkTheme)
+        createNotificationButton(title: "저장", method: #selector(saveGroup), color: TDStyle.color.mainDarkTheme)
     }()
     
     private func createNotificationButton(title: String,
@@ -73,7 +73,7 @@ final class GroupSelectModal: UIViewController {
         let tableView = UITableView(frame: .zero, style: .grouped)
         tableView.backgroundColor = .white
         tableView.contentInset = UIEdgeInsets(top: -35, left: 0, bottom: 0, right: 0)
-        tableView.register(GroupSelectModalTableViewCell.self, forCellReuseIdentifier: "GroupSelectModalTableViewCell")
+        
         return tableView
     }()
     
@@ -96,18 +96,6 @@ final class GroupSelectModal: UIViewController {
             presentationController.prefersGrabberVisible = true
         }
     }
-    
-    private func updateSaveButtonAction() {
-        if selectedCategory != nil {
-            saveButton.setTitle("저장", for: .normal)
-            saveButton.removeTarget(nil, action: nil, for: .allEvents)
-            saveButton.addTarget(self, action: #selector(saveGroup), for: .touchUpInside)
-        } else {
-            saveButton.setTitle("닫기", for: .normal)
-            saveButton.removeTarget(nil, action: nil, for: .allEvents)
-            saveButton.addTarget(self, action: #selector(closeModal), for: .touchUpInside)
-        }
-    }
 }
 
 // MARK: - @objc Method
@@ -124,10 +112,6 @@ extension GroupSelectModal {
         let addGroupViewController = AddGroupViewController()
         addGroupViewController.modalPresentationStyle = .fullScreen
         self.present(addGroupViewController, animated: true, completion: nil)
-    }
-    
-    @objc func closeModal() {
-        dismiss(animated: true, completion: nil)
     }
 }
 
@@ -158,15 +142,14 @@ extension GroupSelectModal {
         
         addGroupButton.snp.makeConstraints { make in
             make.top.equalTo(separatorLine.snp.bottom).offset(4)
-            make.left.left.equalToSuperview().inset(5)
-            make.height.equalTo(36)
+            make.height.equalTo(44)
         }
         
         tableView.snp.remakeConstraints { make in
             make.top.equalTo(addGroupButton.snp.bottom).offset(4)
             make.leading.trailing.bottom.equalTo(view.safeAreaLayoutGuide)
         }
-        
+
     }
     
     private func setAddGroupButton() {
@@ -188,18 +171,18 @@ extension GroupSelectModal: UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: "GroupSelectModalTableViewCell",
-                                                       for: indexPath) as? GroupSelectModalTableViewCell else {
-            fatalError("Unable to dequeue a CategoryTableViewCell.")
-        }
+        let cell = tableView.dequeueReusableCell(withIdentifier: "groupTableViewCellIdentifier", for: indexPath)
+        let group = groupList[indexPath.row]
+        cell.textLabel?.text = group.title
         
-        let category = groupList[indexPath.row]
-        let isSelected = category == selectedCategory
-        cell.configure(with: category, isSelected: isSelected)
+        if let selectedCategory = selectedCategory, selectedCategory == group {
+            cell.accessoryType = .checkmark
+        } else {
+            cell.accessoryType = .none
+        }
         
         return cell
     }
-    
 }
 
 // MARK: - UITableViewDelegate
@@ -216,7 +199,6 @@ extension GroupSelectModal: UITableViewDelegate {
             cell.accessoryType = .checkmark
             cell.tintColor = TDStyle.color.mainDarkTheme
             selectedCategory = groupList[indexPath.row]
-            updateSaveButtonAction()
         }
         
         tableView.deselectRow(at: indexPath, animated: true)
@@ -225,61 +207,10 @@ extension GroupSelectModal: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didDeselectRowAt indexPath: IndexPath) {
         if let cell = tableView.cellForRow(at: indexPath) {
             cell.accessoryType = .none
-            updateSaveButtonAction()
         }
     }
     
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         return 44
-    }
-}
-
-class GroupSelectModalTableViewCell: UITableViewCell {
-    let iconImageView: UIImageView = {
-        let imageView = UIImageView()
-        imageView.contentMode = .scaleAspectFit
-        imageView.translatesAutoresizingMaskIntoConstraints = false
-        return imageView
-    }()
-    
-    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
-        super.init(style: style, reuseIdentifier: reuseIdentifier)
-        setupViews()
-    }
-    
-    required init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-    
-    private func setupViews() {
-        addSubview(iconImageView)
-        iconImageView.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 15).isActive = true
-        iconImageView.centerYAnchor.constraint(equalTo: self.centerYAnchor).isActive = true
-        iconImageView.widthAnchor.constraint(equalToConstant: 30).isActive = true
-        iconImageView.heightAnchor.constraint(equalToConstant: 30).isActive = true
-        
-        textLabel?.translatesAutoresizingMaskIntoConstraints = false
-        textLabel?.leadingAnchor.constraint(equalTo: iconImageView.trailingAnchor, constant: 15).isActive = true
-        textLabel?.centerYAnchor.constraint(equalTo: self.centerYAnchor).isActive = true
-    }
-    
-    func configure(with category: Category, isSelected: Bool) {
-        textLabel?.text = category.title
-        if let colorString = category.color {
-            let color = UIColor(hex: colorString)
-            let imageSize = CGSize(width: 30, height: 30)
-            let roundedImage = UIImage.roundedImage(color: color, size: imageSize)
-            iconImageView.image = roundedImage
-        }
-        accessoryType = isSelected ? .checkmark : .none
-    }
-    
-    private func createCircularImage(with color: UIColor, size: CGSize) -> UIImage {
-        let renderer = UIGraphicsImageRenderer(size: size)
-        return renderer.image { context in
-            context.cgContext.setFillColor(color.cgColor)
-            context.cgContext.addEllipse(in: CGRect(origin: .zero, size: size))
-            context.cgContext.drawPath(using: .fill)
-        }
     }
 }

--- a/ToDwoong/ToDwoong/Presentation/AddTodo/Modals/GroupSelectModal.swift~dev
+++ b/ToDwoong/ToDwoong/Presentation/AddTodo/Modals/GroupSelectModal.swift~dev
@@ -17,7 +17,6 @@ final class GroupSelectModal: UIViewController {
     weak var delegate: GroupSelectModalDelegate?
     var groupList: [Category] = []
     var selectedCategory: Category?
-    let addGroupButton = AddGroupButton(type: .system)
     
     // MARK: - UI Properties
     
@@ -39,7 +38,7 @@ final class GroupSelectModal: UIViewController {
     }()
     
     private lazy var saveButton: UIButton = {
-        createNotificationButton(title: "닫기", method: #selector(closeModal), color: TDStyle.color.mainDarkTheme)
+        createNotificationButton(title: "저장", method: #selector(saveGroup), color: TDStyle.color.mainDarkTheme)
     }()
     
     private func createNotificationButton(title: String,
@@ -63,17 +62,11 @@ final class GroupSelectModal: UIViewController {
         return button
     }
     
-    private let separatorLine: UIView = {
-        let view = UIView()
-        view.backgroundColor = .systemGray4
-        return view
-    }()
-    
     private lazy var tableView: UITableView = {
         let tableView = UITableView(frame: .zero, style: .grouped)
         tableView.backgroundColor = .white
         tableView.contentInset = UIEdgeInsets(top: -35, left: 0, bottom: 0, right: 0)
-        tableView.register(GroupSelectModalTableViewCell.self, forCellReuseIdentifier: "GroupSelectModalTableViewCell")
+        
         return tableView
     }()
     
@@ -86,7 +79,6 @@ final class GroupSelectModal: UIViewController {
         setUI()
         setLayout()
         setTableView()
-        setAddGroupButton()
         configureModalStyle()
     }
     
@@ -96,38 +88,17 @@ final class GroupSelectModal: UIViewController {
             presentationController.prefersGrabberVisible = true
         }
     }
-    
-    private func updateSaveButtonAction() {
-        if selectedCategory != nil {
-            saveButton.setTitle("저장", for: .normal)
-            saveButton.removeTarget(nil, action: nil, for: .allEvents)
-            saveButton.addTarget(self, action: #selector(saveGroup), for: .touchUpInside)
-        } else {
-            saveButton.setTitle("닫기", for: .normal)
-            saveButton.removeTarget(nil, action: nil, for: .allEvents)
-            saveButton.addTarget(self, action: #selector(closeModal), for: .touchUpInside)
-        }
-    }
 }
 
 // MARK: - @objc Method
 
 extension GroupSelectModal {
-    @objc func saveGroup() {
+    @objc
+    func saveGroup() {
         if let selectedCategory = selectedCategory {
             delegate?.groupSelectController(self, didSelectGroup: selectedCategory)
             dismiss(animated: true, completion: nil)
         }
-    }
-    
-    @objc func addGroupAction() {
-        let addGroupViewController = AddGroupViewController()
-        addGroupViewController.modalPresentationStyle = .fullScreen
-        self.present(addGroupViewController, animated: true, completion: nil)
-    }
-    
-    @objc func closeModal() {
-        dismiss(animated: true, completion: nil)
     }
 }
 
@@ -135,7 +106,7 @@ extension GroupSelectModal {
 
 extension GroupSelectModal {
     private func setUI() {
-        [timeNotificationButton, addGroupButton, separatorLine, tableView, saveButton].forEach { view.addSubview($0) }
+        [timeNotificationButton, tableView, saveButton].forEach { view.addSubview($0) }
         view.backgroundColor = .white
     }
     
@@ -150,27 +121,10 @@ extension GroupSelectModal {
             make.trailing.equalToSuperview().offset(-10)
         }
         
-        separatorLine.snp.makeConstraints { make in
-            make.top.equalTo(saveButton.snp.bottom).offset(15)
-            make.leading.trailing.equalTo(view.safeAreaLayoutGuide)
-            make.height.equalTo(0.5)
+        tableView.snp.makeConstraints { make in
+            make.top.equalTo(timeNotificationButton.snp.bottom).offset(16)
+            make.leading.trailing.bottom.equalToSuperview()
         }
-        
-        addGroupButton.snp.makeConstraints { make in
-            make.top.equalTo(separatorLine.snp.bottom).offset(4)
-            make.left.left.equalToSuperview().inset(5)
-            make.height.equalTo(36)
-        }
-        
-        tableView.snp.remakeConstraints { make in
-            make.top.equalTo(addGroupButton.snp.bottom).offset(4)
-            make.leading.trailing.bottom.equalTo(view.safeAreaLayoutGuide)
-        }
-        
-    }
-    
-    private func setAddGroupButton() {
-        addGroupButton.addTarget(self, action: #selector(addGroupAction), for: .touchUpInside)
     }
     
     private func setTableView() {
@@ -188,18 +142,18 @@ extension GroupSelectModal: UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: "GroupSelectModalTableViewCell",
-                                                       for: indexPath) as? GroupSelectModalTableViewCell else {
-            fatalError("Unable to dequeue a CategoryTableViewCell.")
-        }
+        let cell = tableView.dequeueReusableCell(withIdentifier: "groupTableViewCellIdentifier", for: indexPath)
+        let group = groupList[indexPath.row]
+        cell.textLabel?.text = group.title
         
-        let category = groupList[indexPath.row]
-        let isSelected = category == selectedCategory
-        cell.configure(with: category, isSelected: isSelected)
+        if let selectedCategory = selectedCategory, selectedCategory == group {
+            cell.accessoryType = .checkmark
+        } else {
+            cell.accessoryType = .none
+        }
         
         return cell
     }
-    
 }
 
 // MARK: - UITableViewDelegate
@@ -216,7 +170,6 @@ extension GroupSelectModal: UITableViewDelegate {
             cell.accessoryType = .checkmark
             cell.tintColor = TDStyle.color.mainDarkTheme
             selectedCategory = groupList[indexPath.row]
-            updateSaveButtonAction()
         }
         
         tableView.deselectRow(at: indexPath, animated: true)
@@ -225,61 +178,10 @@ extension GroupSelectModal: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didDeselectRowAt indexPath: IndexPath) {
         if let cell = tableView.cellForRow(at: indexPath) {
             cell.accessoryType = .none
-            updateSaveButtonAction()
         }
     }
     
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return 44
-    }
-}
-
-class GroupSelectModalTableViewCell: UITableViewCell {
-    let iconImageView: UIImageView = {
-        let imageView = UIImageView()
-        imageView.contentMode = .scaleAspectFit
-        imageView.translatesAutoresizingMaskIntoConstraints = false
-        return imageView
-    }()
-    
-    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
-        super.init(style: style, reuseIdentifier: reuseIdentifier)
-        setupViews()
-    }
-    
-    required init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-    
-    private func setupViews() {
-        addSubview(iconImageView)
-        iconImageView.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 15).isActive = true
-        iconImageView.centerYAnchor.constraint(equalTo: self.centerYAnchor).isActive = true
-        iconImageView.widthAnchor.constraint(equalToConstant: 30).isActive = true
-        iconImageView.heightAnchor.constraint(equalToConstant: 30).isActive = true
-        
-        textLabel?.translatesAutoresizingMaskIntoConstraints = false
-        textLabel?.leadingAnchor.constraint(equalTo: iconImageView.trailingAnchor, constant: 15).isActive = true
-        textLabel?.centerYAnchor.constraint(equalTo: self.centerYAnchor).isActive = true
-    }
-    
-    func configure(with category: Category, isSelected: Bool) {
-        textLabel?.text = category.title
-        if let colorString = category.color {
-            let color = UIColor(hex: colorString)
-            let imageSize = CGSize(width: 30, height: 30)
-            let roundedImage = UIImage.roundedImage(color: color, size: imageSize)
-            iconImageView.image = roundedImage
-        }
-        accessoryType = isSelected ? .checkmark : .none
-    }
-    
-    private func createCircularImage(with color: UIColor, size: CGSize) -> UIImage {
-        let renderer = UIGraphicsImageRenderer(size: size)
-        return renderer.image { context in
-            context.cgContext.setFillColor(color.cgColor)
-            context.cgContext.addEllipse(in: CGRect(origin: .zero, size: size))
-            context.cgContext.drawPath(using: .fill)
-        }
+        return 60
     }
 }

--- a/ToDwoong/ToDwoong/Presentation/AddTodo/Modals/GroupSelectModal.swift~dev_0
+++ b/ToDwoong/ToDwoong/Presentation/AddTodo/Modals/GroupSelectModal.swift~dev_0
@@ -17,7 +17,6 @@ final class GroupSelectModal: UIViewController {
     weak var delegate: GroupSelectModalDelegate?
     var groupList: [Category] = []
     var selectedCategory: Category?
-    let addGroupButton = AddGroupButton(type: .system)
     
     // MARK: - UI Properties
     
@@ -39,7 +38,7 @@ final class GroupSelectModal: UIViewController {
     }()
     
     private lazy var saveButton: UIButton = {
-        createNotificationButton(title: "닫기", method: #selector(closeModal), color: TDStyle.color.mainDarkTheme)
+        createNotificationButton(title: "저장", method: #selector(saveGroup), color: TDStyle.color.mainDarkTheme)
     }()
     
     private func createNotificationButton(title: String,
@@ -63,17 +62,11 @@ final class GroupSelectModal: UIViewController {
         return button
     }
     
-    private let separatorLine: UIView = {
-        let view = UIView()
-        view.backgroundColor = .systemGray4
-        return view
-    }()
-    
     private lazy var tableView: UITableView = {
         let tableView = UITableView(frame: .zero, style: .grouped)
         tableView.backgroundColor = .white
         tableView.contentInset = UIEdgeInsets(top: -35, left: 0, bottom: 0, right: 0)
-        tableView.register(GroupSelectModalTableViewCell.self, forCellReuseIdentifier: "GroupSelectModalTableViewCell")
+        
         return tableView
     }()
     
@@ -86,7 +79,6 @@ final class GroupSelectModal: UIViewController {
         setUI()
         setLayout()
         setTableView()
-        setAddGroupButton()
         configureModalStyle()
     }
     
@@ -96,38 +88,17 @@ final class GroupSelectModal: UIViewController {
             presentationController.prefersGrabberVisible = true
         }
     }
-    
-    private func updateSaveButtonAction() {
-        if selectedCategory != nil {
-            saveButton.setTitle("저장", for: .normal)
-            saveButton.removeTarget(nil, action: nil, for: .allEvents)
-            saveButton.addTarget(self, action: #selector(saveGroup), for: .touchUpInside)
-        } else {
-            saveButton.setTitle("닫기", for: .normal)
-            saveButton.removeTarget(nil, action: nil, for: .allEvents)
-            saveButton.addTarget(self, action: #selector(closeModal), for: .touchUpInside)
-        }
-    }
 }
 
 // MARK: - @objc Method
 
 extension GroupSelectModal {
-    @objc func saveGroup() {
+    @objc
+    func saveGroup() {
         if let selectedCategory = selectedCategory {
             delegate?.groupSelectController(self, didSelectGroup: selectedCategory)
             dismiss(animated: true, completion: nil)
         }
-    }
-    
-    @objc func addGroupAction() {
-        let addGroupViewController = AddGroupViewController()
-        addGroupViewController.modalPresentationStyle = .fullScreen
-        self.present(addGroupViewController, animated: true, completion: nil)
-    }
-    
-    @objc func closeModal() {
-        dismiss(animated: true, completion: nil)
     }
 }
 
@@ -135,7 +106,7 @@ extension GroupSelectModal {
 
 extension GroupSelectModal {
     private func setUI() {
-        [timeNotificationButton, addGroupButton, separatorLine, tableView, saveButton].forEach { view.addSubview($0) }
+        [timeNotificationButton, tableView, saveButton].forEach { view.addSubview($0) }
         view.backgroundColor = .white
     }
     
@@ -150,27 +121,10 @@ extension GroupSelectModal {
             make.trailing.equalToSuperview().offset(-10)
         }
         
-        separatorLine.snp.makeConstraints { make in
-            make.top.equalTo(saveButton.snp.bottom).offset(15)
-            make.leading.trailing.equalTo(view.safeAreaLayoutGuide)
-            make.height.equalTo(0.5)
+        tableView.snp.makeConstraints { make in
+            make.top.equalTo(timeNotificationButton.snp.bottom).offset(16)
+            make.leading.trailing.bottom.equalToSuperview()
         }
-        
-        addGroupButton.snp.makeConstraints { make in
-            make.top.equalTo(separatorLine.snp.bottom).offset(4)
-            make.left.left.equalToSuperview().inset(5)
-            make.height.equalTo(36)
-        }
-        
-        tableView.snp.remakeConstraints { make in
-            make.top.equalTo(addGroupButton.snp.bottom).offset(4)
-            make.leading.trailing.bottom.equalTo(view.safeAreaLayoutGuide)
-        }
-        
-    }
-    
-    private func setAddGroupButton() {
-        addGroupButton.addTarget(self, action: #selector(addGroupAction), for: .touchUpInside)
     }
     
     private func setTableView() {
@@ -188,18 +142,18 @@ extension GroupSelectModal: UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: "GroupSelectModalTableViewCell",
-                                                       for: indexPath) as? GroupSelectModalTableViewCell else {
-            fatalError("Unable to dequeue a CategoryTableViewCell.")
-        }
+        let cell = tableView.dequeueReusableCell(withIdentifier: "groupTableViewCellIdentifier", for: indexPath)
+        let group = groupList[indexPath.row]
+        cell.textLabel?.text = group.title
         
-        let category = groupList[indexPath.row]
-        let isSelected = category == selectedCategory
-        cell.configure(with: category, isSelected: isSelected)
+        if let selectedCategory = selectedCategory, selectedCategory == group {
+            cell.accessoryType = .checkmark
+        } else {
+            cell.accessoryType = .none
+        }
         
         return cell
     }
-    
 }
 
 // MARK: - UITableViewDelegate
@@ -216,7 +170,6 @@ extension GroupSelectModal: UITableViewDelegate {
             cell.accessoryType = .checkmark
             cell.tintColor = TDStyle.color.mainDarkTheme
             selectedCategory = groupList[indexPath.row]
-            updateSaveButtonAction()
         }
         
         tableView.deselectRow(at: indexPath, animated: true)
@@ -225,61 +178,10 @@ extension GroupSelectModal: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didDeselectRowAt indexPath: IndexPath) {
         if let cell = tableView.cellForRow(at: indexPath) {
             cell.accessoryType = .none
-            updateSaveButtonAction()
         }
     }
     
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return 44
-    }
-}
-
-class GroupSelectModalTableViewCell: UITableViewCell {
-    let iconImageView: UIImageView = {
-        let imageView = UIImageView()
-        imageView.contentMode = .scaleAspectFit
-        imageView.translatesAutoresizingMaskIntoConstraints = false
-        return imageView
-    }()
-    
-    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
-        super.init(style: style, reuseIdentifier: reuseIdentifier)
-        setupViews()
-    }
-    
-    required init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-    
-    private func setupViews() {
-        addSubview(iconImageView)
-        iconImageView.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 15).isActive = true
-        iconImageView.centerYAnchor.constraint(equalTo: self.centerYAnchor).isActive = true
-        iconImageView.widthAnchor.constraint(equalToConstant: 30).isActive = true
-        iconImageView.heightAnchor.constraint(equalToConstant: 30).isActive = true
-        
-        textLabel?.translatesAutoresizingMaskIntoConstraints = false
-        textLabel?.leadingAnchor.constraint(equalTo: iconImageView.trailingAnchor, constant: 15).isActive = true
-        textLabel?.centerYAnchor.constraint(equalTo: self.centerYAnchor).isActive = true
-    }
-    
-    func configure(with category: Category, isSelected: Bool) {
-        textLabel?.text = category.title
-        if let colorString = category.color {
-            let color = UIColor(hex: colorString)
-            let imageSize = CGSize(width: 30, height: 30)
-            let roundedImage = UIImage.roundedImage(color: color, size: imageSize)
-            iconImageView.image = roundedImage
-        }
-        accessoryType = isSelected ? .checkmark : .none
-    }
-    
-    private func createCircularImage(with color: UIColor, size: CGSize) -> UIImage {
-        let renderer = UIGraphicsImageRenderer(size: size)
-        return renderer.image { context in
-            context.cgContext.setFillColor(color.cgColor)
-            context.cgContext.addEllipse(in: CGRect(origin: .zero, size: size))
-            context.cgContext.drawPath(using: .fill)
-        }
+        return 60
     }
 }

--- a/ToDwoong/ToDwoong/Presentation/AddTodo/ViewController/AddTodoViewController.swift
+++ b/ToDwoong/ToDwoong/Presentation/AddTodo/ViewController/AddTodoViewController.swift
@@ -467,12 +467,6 @@ extension AddTodoViewController: UITableViewDelegate, UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        if indexPath.section == 0 && indexPath.row == 2 {
-            if let location = selectedPlace, !location.isEmpty {
-                return 80
-            }
-        }
-        
         if indexPath.section == 1 && indexPath.row == 0 {
             let rowCount = CGFloat((selectedTimesAlarm.count + 2) / 3)
             return 44 + rowCount * (30 + 10)


### PR DESCRIPTION
<!-- 
<제목 양식>

[기능 라벨] #이슈번호 - 기능 1줄 요약
ex) [Feat] #1 - 프로젝트 세팅
ex) [Docs] #2 - Readme 파일 수정
-->


## 연관된 이슈
<!-- ex) #이슈번호 -->

> #114 

## 작업 내용
<!--
이번 PR에서 작업한 내용을 간략히 설명해주세요
메서드의 경우 사용 예시를 적어주세요
-->

>그룹 리스트 페이지 편집버튼 모달창 연결,
 그룹 추가 버튼 추가,
 그룹 선택안했을때 닫기 > 선택시 저장으로 분기처리,
 그룹추가 버튼 한줄 전체적용,
 높이 44적용,
 위치값 칩뷰 위치 변경 (개행 > 왼쪽),
 위치값 칩뷰 15자이상 '..'처리,
 그룹추가 >투두출가 그룹리스트NotificationCenter 추가

## 리뷰 요구사항
<!--
리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
-->

>82d1c6039f4917edf92b034290cd256832b3a84c NotificationCenter추가 부분입니다. 제대로 적용했는지 확인부탁드려요 😊


## 스크린샷
|위치 15자이상|gif|
|---|---|
|<img src="https://github.com/NBCAMP-ToDwoong/todwoong/assets/77021071/6fedf19c-4a3c-4eac-b85f-e4a980dab629" width="300"/>|<img src="https://github.com/NBCAMP-ToDwoong/todwoong/assets/77021071/92042c3f-3bbc-4318-83b6-2df750947419" width="300"/>|


